### PR TITLE
(#26, #28) Path parameters to query string parameters; remove requestedFields parameter

### DIFF
--- a/integration-tests/features/autosuggest/aliases-only.feature
+++ b/integration-tests/features/autosuggest/aliases-only.feature
@@ -5,8 +5,8 @@ Feature: Autosuggest, restricted to drug aliases.
 
     Scenario Outline: Given the search text and type, validate the query result.
 
-        Given path 'Autosuggest', search
-        And params { matchType: <match>, size: 3,  includeResourceTypes: [DrugAlias]}
+        Given path 'Autosuggest'
+        And params { searchText: <search>, matchType: <match>, size: 3,  includeResourceTypes: [DrugAlias]}
         When method get
         Then status 200
         And match response == read( expected )

--- a/integration-tests/features/autosuggest/legacy.feature
+++ b/integration-tests/features/autosuggest/legacy.feature
@@ -6,8 +6,8 @@ Feature: Autosuggest, including only PreferredName and USBrandName name types in
 
     Scenario Outline: Given the search text and type, validate the query result.
 
-        Given path 'Autosuggest', search
-        And params { matchType: <match>, size: 5, includeNameTypes: ['USBrandName', 'PreferredName'] }
+        Given path 'Autosuggest'
+        And params { searchText: <search>, matchType: <match>, size: 5, includeNameTypes: ['USBrandName', 'PreferredName'] }
         When method get
         Then status 200
         And match response == read( expected )

--- a/integration-tests/features/drugs/expand/legacy.feature
+++ b/integration-tests/features/drugs/expand/legacy.feature
@@ -13,7 +13,7 @@ Feature: Expand, with includedNameTypes set to 'PreferredName', 'USBrandName'
         And match response == read( expected )
 
         Examples:
-            | letter | from | expected       |
-            | a      | 0    | legacy-a.json  |
-            | s      | 20   | legacy-s.json  |
+            | letter | from | expected          |
+            | a      | 0    | legacy-a.json     |
+            | s      | 20   | legacy-s.json     |
             | #      | 5    | legacy-hash.json  |

--- a/integration-tests/features/drugs/getByName/mismatch.feature
+++ b/integration-tests/features/drugs/getByName/mismatch.feature
@@ -12,9 +12,9 @@ Feature: Attempt to retrieve definition by specifying a mismatched pretty url na
         And match response == read( expected )
 
         Examples:
-            | prettyName    | expected                      |
-            | chicken       | mismatch-no-match.json     |
-            | autologous-ic9-gd2 | mismatch-partial.json |
-            | egfr antisense dna | mismatch-spaces.json |
-            | BENZOYLPHENYLUREA  | mismatch-uppercase.json |
+            | prettyName         | expected                        |
+            | chicken            | mismatch-no-match.json          |
+            | autologous-ic9-gd2 | mismatch-partial.json           |
+            | egfr antisense dna | mismatch-spaces.json            |
+            | BENZOYLPHENYLUREA  | mismatch-uppercase.json         |
             | s-3304             | mismatch-preferred-instead.json |

--- a/integration-tests/features/drugs/search/name-match.feature
+++ b/integration-tests/features/drugs/search/name-match.feature
@@ -5,21 +5,21 @@ Feature: Search for variations on a drug name.
 
     Scenario Outline: Search for a drug name, varying the Match type and a preferred name versus an alias.
 
-        Given path 'Drugs', 'search', name
-        And params { matchType: <match>, size: 5 }
+        Given path 'Drugs', 'Search'
+        And params { query: <name>, matchType: <match>, size: 5 }
         When method get
         Then status 200
         And match response == read( expected )
 
         Examples:
-            | name              | match    | expected                                     |
-            | palbociclib       | begins   | name-match-begin-exact-preferred.json        |
-            | paclitaxel        | contains | name-match-contain-exact-preferred.json      |
-            | mycobutin         | begins   | name-match-begin-exact-alias.json            |
-            | comtan            | contains | name-match-contain-exact-alias.json          |
+            | name                | match    | expected                                     |
+            | palbociclib         | begins   | name-match-begin-exact-preferred.json        |
+            | paclitaxel          | contains | name-match-contain-exact-preferred.json      |
+            | mycobutin           | begins   | name-match-begin-exact-alias.json            |
+            | comtan              | contains | name-match-contain-exact-alias.json          |
             # partial names
-            | vaccinia          | contains | name-match-contain-partial-preferred.json    |
+            | vaccinia            | contains | name-match-contain-partial-preferred.json    |
             # special cases
-            | neu intracellular | contains | name-match-contains-spaces-preferred.json    |
-            | 70-kD             | contains | name-match-contains-dash-preferred.json
-            | 4-thiazolidinedione        | contains | name-match-contains-dash-alias.json
+            | neu intracellular   | contains | name-match-contains-spaces-preferred.json    |
+            | 70-kD               | contains | name-match-contains-dash-preferred.json      |
+            | 4-thiazolidinedione | contains | name-match-contains-dash-alias.json          |

--- a/src/NCI.OCPL.Api.DrugDictionary/Controllers/AutosuggestController.cs
+++ b/src/NCI.OCPL.Api.DrugDictionary/Controllers/AutosuggestController.cs
@@ -49,12 +49,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
         }
 
         /// <summary>
-        /// Search for Terms based on autosuggest criteria
-        /// </summary>
-        /// <returns>An array of Suggestion objects</returns>
-
-        /// <summary>
-        /// Searches for dictionary terms with names matching the query text.
+        /// Searches for drug dictionary terms with names matching the query text.
         /// </summary>
         /// <param name="searchText">Text to match against</param>
         /// <param name="matchType">Should the search match items beginning with the search text, or containing it?</param>
@@ -62,15 +57,20 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
         /// <param name="includeResourceTypes">The DrugResourceTypes to include. Default: All</param>
         /// <param name="includeNameTypes">The name types to include. Default: All</param>
         /// <param name="excludeNameTypes">The name types to exclude. Default: All</param>
-        /// <returns></returns>
-        [HttpGet("{*searchText:required}")]
-        public async Task<Suggestion[]> GetSuggestions(string searchText,
+        /// <returns>A Suggestion result containing the desired records.</returns>
+        [HttpGet("")]
+        public async Task<Suggestion[]> GetSuggestions(
+            [FromQuery] string searchText,
             [FromQuery] MatchType matchType = MatchType.Begins, [FromQuery] int size = 20,
             [FromQuery] DrugResourceType[] includeResourceTypes = null,
             [FromQuery] TermNameType[] includeNameTypes = null,
             [FromQuery] TermNameType[] excludeNameTypes = null
             )
         {
+            if(string.IsNullOrWhiteSpace(searchText))
+            {
+                throw new APIErrorException(400, "You must specify a search string.");
+            }
 
             if (!Enum.IsDefined(typeof(MatchType), matchType))
                 throw new APIErrorException(400, "The `matchType` parameter must be either 'Begins' or 'Contains'.");

--- a/src/NCI.OCPL.Api.DrugDictionary/Controllers/DrugsController.cs
+++ b/src/NCI.OCPL.Api.DrugDictionary/Controllers/DrugsController.cs
@@ -9,8 +9,6 @@ using System.Net;
 
 namespace NCI.OCPL.Api.DrugDictionary.Controllers
 {
-
-
     /// <summary>
     /// Controller for routes used when searching for or retrieving
     /// multiple Terms.
@@ -67,7 +65,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
         /// <returns>A DrugTermResults object containing the desired records.</returns>
         [HttpGet("expand/{character}")]
         public async Task<DrugTermResults> Expand(char character,
-            [FromQuery] int size = 100, [FromQuery] int from = 0,
+            [FromQuery] int size = 100,
+            [FromQuery] int from = 0,
             [FromQuery] DrugResourceType[] includeResourceTypes = null,
             [FromQuery] TermNameType[] includeNameTypes = null,
             [FromQuery] TermNameType[] excludeNameTypes = null,
@@ -187,9 +186,13 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
         /// <param name="from">The offset into the overall set to use for the first record.</param>
         /// <param name="requestedFields">The fields to be populated with this response.</param>
         /// <returns>A DrugTermResults object containing the desired records.</returns>
-        [HttpGet("search/{*query:required}")]
-        public async Task<DrugTermResults> Search(string query, [FromQuery] MatchType matchType = MatchType.Begins,
-            [FromQuery] int size = 100, [FromQuery] int from = 0, [FromQuery] string[] requestedFields = null
+        [HttpGet("search")]
+        public async Task<DrugTermResults> Search(
+            [FromQuery] string query,
+            [FromQuery] MatchType matchType = MatchType.Begins,
+            [FromQuery] int size = 100,
+            [FromQuery] int from = 0,
+            [FromQuery] string[] requestedFields = null
         )
         {
             if(String.IsNullOrWhiteSpace(query))

--- a/src/NCI.OCPL.Api.DrugDictionary/Controllers/DrugsController.cs
+++ b/src/NCI.OCPL.Api.DrugDictionary/Controllers/DrugsController.cs
@@ -61,7 +61,6 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
         /// <param name="includeResourceTypes">The DrugResourceTypes to include. Default: All</param>
         /// <param name="includeNameTypes">The name types to include. Default: All</param>
         /// <param name="excludeNameTypes">The name types to exclude. Default: All</param>
-        /// <param name="requestedFields">The fields to retrieve.  If not specified, defaults to all fields except media and related resources.</param>
         /// <returns>A DrugTermResults object containing the desired records.</returns>
         [HttpGet("expand/{character}")]
         public async Task<DrugTermResults> Expand(char character,
@@ -69,8 +68,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
             [FromQuery] int from = 0,
             [FromQuery] DrugResourceType[] includeResourceTypes = null,
             [FromQuery] TermNameType[] includeNameTypes = null,
-            [FromQuery] TermNameType[] excludeNameTypes = null,
-            [FromQuery] string[] requestedFields = null
+            [FromQuery] TermNameType[] excludeNameTypes = null
         )
         {
             if (size <= 0)
@@ -91,11 +89,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
             if (excludeNameTypes == null)
                 excludeNameTypes = new TermNameType[0];
 
-            if (requestedFields == null || requestedFields.Length == 0 || requestedFields.Where(f => !String.IsNullOrWhiteSpace(f)).Count() == 0)
-                requestedFields = DEFAULT_FIELD_NAMES;
-
             DrugTermResults res = await _termsQueryService.Expand(character, size, from,
-                includeResourceTypes, includeNameTypes, excludeNameTypes, requestedFields);
+                includeResourceTypes, includeNameTypes, excludeNameTypes);
 
             return res;
         }
@@ -108,15 +103,13 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
         /// <param name="includeResourceTypes">The DrugResourceTypes to include. Default: All</param>
         /// <param name="includeNameTypes">The name types to include. Default: All</param>
         /// <param name="excludeNameTypes">The name types to exclude. Default: All</param>
-        /// <param name="requestedFields">The fields to retrieve.  If not specified, defaults to all fields except media and related resources.</param>
         /// <returns>A DrugTermResults object containing the desired records.</returns>
         [HttpGet("")]
         public async Task<DrugTermResults> GetAll(
             [FromQuery] int size = 100, [FromQuery] int from = 0,
             [FromQuery] DrugResourceType[] includeResourceTypes = null,
             [FromQuery] TermNameType[] includeNameTypes = null,
-            [FromQuery] TermNameType[] excludeNameTypes = null,
-            [FromQuery] string[] requestedFields = null
+            [FromQuery] TermNameType[] excludeNameTypes = null
         )
         {
             if (size <= 0)
@@ -137,11 +130,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
             if (excludeNameTypes == null)
                 excludeNameTypes = new TermNameType[0];
 
-            if (requestedFields == null || requestedFields.Length == 0 || requestedFields.Where(f => !String.IsNullOrWhiteSpace(f)).Count() == 0)
-                requestedFields = DEFAULT_FIELD_NAMES;
-
             DrugTermResults res = await _termsQueryService.GetAll(size, from,
-                includeResourceTypes, includeNameTypes, excludeNameTypes, requestedFields);
+                includeResourceTypes, includeNameTypes, excludeNameTypes);
 
             return res;
         }
@@ -184,15 +174,13 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
         /// <param name="matchType">Should the search match items beginning with the search text, or containing it? Default: Begin.</param>
         /// <param name="size">The number of records to retrieve. Default: 100.</param>
         /// <param name="from">The offset into the overall set to use for the first record.</param>
-        /// <param name="requestedFields">The fields to be populated with this response.</param>
         /// <returns>A DrugTermResults object containing the desired records.</returns>
         [HttpGet("search")]
         public async Task<DrugTermResults> Search(
             [FromQuery] string query,
             [FromQuery] MatchType matchType = MatchType.Begins,
             [FromQuery] int size = 100,
-            [FromQuery] int from = 0,
-            [FromQuery] string[] requestedFields = null
+            [FromQuery] int from = 0
         )
         {
             if(String.IsNullOrWhiteSpace(query))
@@ -210,11 +198,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Controllers
             // query uses a catch-all route, make sure it's been decoded.
             query = WebUtility.UrlDecode(query);
 
-            // if requestedFields is empty populate it with default values
-            if (requestedFields == null || requestedFields.Length == 0 || requestedFields.Where(f => f != null).Count() == 0)
-                requestedFields = DEFAULT_FIELD_NAMES;
-
-            DrugTermResults res = await _termsQueryService.Search(query, matchType, size, from, requestedFields);
+            DrugTermResults res = await _termsQueryService.Search(query, matchType, size, from);
             return res;
         }
 

--- a/src/NCI.OCPL.Api.DrugDictionary/Interfaces/IDrugsQueryService.cs
+++ b/src/NCI.OCPL.Api.DrugDictionary/Interfaces/IDrugsQueryService.cs
@@ -31,11 +31,10 @@ namespace NCI.OCPL.Api.DrugDictionary
         /// <param name="includeResourceTypes">The DrugResourceTypes to include. Default: All</param>
         /// <param name="includeNameTypes">The name types to include. Default: All</param>
         /// <param name="excludeNameTypes">The name types to exclude. Default: All</param>
-        /// <param name="requestedFields">The fields to retrieve.  If not specified, defaults to TermName, Pronunciation, and Definition.</param>
         /// <returns>A DrugTermResults object containing the desired records.</returns>
         Task<DrugTermResults> GetAll(int size, int from,
-            DrugResourceType[] includeResourceTypes, TermNameType[] includeNameTypes, TermNameType[] excludeNameTypes,
-            string[] requestedFields);
+            DrugResourceType[] includeResourceTypes, TermNameType[] includeNameTypes, TermNameType[] excludeNameTypes
+        );
 
         /// <summary>
         /// Search for drug definitions based on search criteria.
@@ -43,10 +42,9 @@ namespace NCI.OCPL.Api.DrugDictionary
         /// <param name="matchType">Defines if the search should begin with or contain the key word</param>
         /// <param name="size">Defines the size of the search</param>
         /// <param name="from">Defines the Offset for search</param>
-        /// <param name="requestedFields">The list of fields that needs to be sent in the response</param>
         /// <returns>A DrugTermResults object containing the desired records.</returns>
         /// </summary>
-        Task<DrugTermResults> Search(string query, MatchType matchType, int size, int from, string[] requestedFields);
+        Task<DrugTermResults> Search(string query, MatchType matchType, int size, int from);
 
         /// <summary>
         /// List all drug dictionary entries starting with the same first character.
@@ -56,12 +54,10 @@ namespace NCI.OCPL.Api.DrugDictionary
         /// <param name="includeResourceTypes">The DrugResourceTypes to include. Default: All</param>
         /// <param name="includeNameTypes">The name types to include. Default: All</param>
         /// <param name="excludeNameTypes">The name types to exclude. Default: All</param>
-        /// <param name="requestedFields"> The list of fields that needs to be sent in the response</param>
         /// <returns>A DrugTermResults object containing the desired records.</returns>
         /// </summary>
         Task<DrugTermResults> Expand(char firstCharacter, int size, int from,
-            DrugResourceType[] includeResourceTypes, TermNameType[] includeNameTypes, TermNameType[] excludeNameTypes,
-            string[] requestedFields
+            DrugResourceType[] includeResourceTypes, TermNameType[] includeNameTypes, TermNameType[] excludeNameTypes
         );
     }
 }

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Controllers/DrugsControllerTests.Expand.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Controllers/DrugsControllerTests.Expand.cs
@@ -37,8 +37,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<int>(),
                     It.IsAny<DrugResourceType[]>(),
                     It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<TermNameType[]>()
                 )
             )
             .Returns(Task.FromResult(new DrugTermResults()));
@@ -54,8 +53,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                 svc => svc.Expand('s', DEFAULT_SEARCH_SIZE, DEFAULT_SEARCH_FROM,
                     DEFAULT_DRUG_RESOURCE_TYPE_LIST,
                     DEFAULT_INCLUDED_TERM_TYPE_LIST,
-                    DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    DEFAULT_REQUESTED_FIELD_LIST ),
+                    DEFAULT_EXCLUDED_TERM_TYPE_LIST ),
                 Times.Once,
                 "ITermsQueryService::Expand() should be called once, using default values."
             );
@@ -76,8 +74,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<int>(),
                     It.IsAny<DrugResourceType[]>(),
                     It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<TermNameType[]>()
                 )
             )
             .Returns(Task.FromResult(new DrugTermResults()));
@@ -87,8 +84,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
             await controller.Expand('s', -1, DEFAULT_SEARCH_FROM,
                 DEFAULT_DRUG_RESOURCE_TYPE_LIST,
                 DEFAULT_INCLUDED_TERM_TYPE_LIST,
-                DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                DEFAULT_REQUESTED_FIELD_LIST
+                DEFAULT_EXCLUDED_TERM_TYPE_LIST
             );
 
             // Verify that the query layer is called:
@@ -96,7 +92,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
             //  b) exactly once.
             querySvc.Verify(
                 svc => svc.Expand('s', DEFAULT_SEARCH_SIZE, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST, DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST, DEFAULT_REQUESTED_FIELD_LIST),
+                    DEFAULT_DRUG_RESOURCE_TYPE_LIST, DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST),
                 Times.Once,
                 "ITermsQueryService::Expand() should be called once, with the updated value for size"
             );
@@ -117,8 +113,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<int>(),
                     It.IsAny<DrugResourceType[]>(),
                     It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<TermNameType[]>()
                 )
             )
             .Returns(Task.FromResult(new DrugTermResults()));
@@ -132,128 +127,9 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
             //  b) exactly once.
             querySvc.Verify(
                 svc => svc.Expand('s', 10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST, DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST, DEFAULT_REQUESTED_FIELD_LIST),
+                    DEFAULT_DRUG_RESOURCE_TYPE_LIST, DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST),
                 Times.Once,
                 "ITermsQueryService::Expandl() should be called once, with the updated value for from"
-            );
-        }
-
-        /// <summary>
-        /// Verify that Expand behaves in the expected manner when requestedFields is null.
-        /// </summary>
-        [Fact]
-        public async void Expand_NullRequestedFields()
-        {
-            // Create a mock query that always returns the same result.
-            Mock<IDrugsQueryService> querySvc = new Mock<IDrugsQueryService>();
-            querySvc.Setup(
-                svc => svc.Expand(
-                    It.IsAny<char>(),
-                    It.IsAny<int>(),
-                    It.IsAny<int>(),
-                    It.IsAny<DrugResourceType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
-                )
-            )
-            .Returns(Task.FromResult(new DrugTermResults()));
-
-            // Call the controller, we don't care about the actual return value.
-            DrugsController controller = new DrugsController(NullLogger<DrugsController>.Instance, querySvc.Object);
-            await controller.Expand('s', 10, -1, null);
-
-            // Verify that the query layer is called:
-            //  a) with the expected updated values for requestedFields.
-            //  b) exactly once.
-            querySvc.Verify(
-                svc => svc.Expand('s', 10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    DEFAULT_REQUESTED_FIELD_LIST),
-                Times.Once,
-                "ITermsQueryService::Expandl() should be called once, with the updated value for requestedFields"
-            );
-        }
-
-        /// <summary>
-        /// Verify that Expand behaves in the expected manner when requestedFields is invalid
-        /// by having any array items that are null.
-        /// </summary>
-        [Fact]
-        public async void Expand_InvalidRequestedFields()
-        {
-            // Create a mock query that always returns the same result.
-            Mock<IDrugsQueryService> querySvc = new Mock<IDrugsQueryService>();
-            querySvc.Setup(
-                svc => svc.Expand(
-                    It.IsAny<char>(),
-                    It.IsAny<int>(),
-                    It.IsAny<int>(),
-                    It.IsAny<DrugResourceType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
-                )
-            )
-            .Returns(Task.FromResult(new DrugTermResults()));
-
-            // Call the controller, we don't care about the actual return value.
-            DrugsController controller = new DrugsController(NullLogger<DrugsController>.Instance, querySvc.Object);
-            await controller.Expand('s', 10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    new string[] { null, null, null });
-
-            // Verify that the query layer is called:
-            //  a) with the expected updated values for requestedFields.
-            //  b) exactly once.
-            querySvc.Verify(
-                svc => svc.Expand('s', 10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    DEFAULT_REQUESTED_FIELD_LIST),
-                Times.Once,
-                "ITermsQueryService::Expandl() should be called once, with the updated value for requestedFields"
-            );
-        }
-
-        /// <summary>
-        /// Verify that Expand behaves in the expected manner when requestedFields is an empty array.
-        /// </summary>
-        [Fact]
-        public async void Expand_EmptyRequestedFields()
-        {
-            // Create a mock query that always returns the same result.
-            Mock<IDrugsQueryService> querySvc = new Mock<IDrugsQueryService>();
-            querySvc.Setup(
-                svc => svc.Expand(
-                    It.IsAny<char>(),
-                    It.IsAny<int>(),
-                    It.IsAny<int>(),
-                    It.IsAny<DrugResourceType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
-                )
-            )
-            .Returns(Task.FromResult(new DrugTermResults()));
-
-            // Call the controller, we don't care about the actual return value.
-            DrugsController controller = new DrugsController(NullLogger<DrugsController>.Instance, querySvc.Object);
-            await controller.Expand('s', 10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST, new string[] { });
-
-            // Verify that the query layer is called:
-            //  a) with the expected updated values for requestedFields.
-            //  b) exactly once.
-            querySvc.Verify(
-                svc => svc.Expand('s', 10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST, DEFAULT_REQUESTED_FIELD_LIST),
-                Times.Once,
-                "ITermsQueryService::Expandl() should be called once, with the updated value for requestedFields"
             );
         }
 
@@ -266,8 +142,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
         {
             Mock<IDrugsQueryService> termsQueryService = new Mock<IDrugsQueryService>();
             DrugsController controller = new DrugsController(NullLogger<DrugsController>.Instance, termsQueryService.Object);
-            string[] requestedFields = new string[] { "termId", "name", "firstLetter", "prettyUrlName", "definition", "aliases", "drugInfoSummaryLink", "nciConceptId", "nciConceptName", "type", "termNameType" };
-
+            
             DrugTermResults drugTermResults = new DrugTermResults()
             {
                 Results = new DrugTerm[] {
@@ -355,24 +230,20 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<int>(),
                     It.IsAny<DrugResourceType[]>(),
                     It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<TermNameType[]>()
                 )
             )
             .Returns(Task.FromResult(drugTermResults));
 
             DrugTermResults actualReslts = await controller.Expand('s', 5, 10, DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                requestedFields);
+                DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST);
 
             // Verify that the service layer is called:
             //  a) with the expected values.
             //  b) exactly once.
             termsQueryService.Verify(
                 svc => svc.Expand('s', 5, 10, DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    new string[] { "termId", "name", "firstLetter", "prettyUrlName", "definition", "aliases", "drugInfoSummaryLink", "nciConceptId", "nciConceptName", "type", "termNameType" }
-                ),
+                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST),
                 Times.Once
             );
 

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Controllers/DrugsControllerTests.GetAll.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Controllers/DrugsControllerTests.GetAll.cs
@@ -28,8 +28,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<int>(),
                     It.IsAny<DrugResourceType[]>(),
                     It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<TermNameType[]>()
                 )
             )
             .Returns(Task.FromResult(new DrugTermResults()));
@@ -45,8 +44,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                 svc => svc.GetAll(DEFAULT_SEARCH_SIZE, DEFAULT_SEARCH_FROM,
                     DEFAULT_DRUG_RESOURCE_TYPE_LIST,
                     DEFAULT_INCLUDED_TERM_TYPE_LIST,
-                    DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    DEFAULT_REQUESTED_FIELD_LIST),
+                    DEFAULT_EXCLUDED_TERM_TYPE_LIST),
                 Times.Once,
                 "ITermsQueryService::GetAll() should be called once, using default values."
             );
@@ -66,8 +64,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<int>(),
                     It.IsAny<DrugResourceType[]>(),
                     It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<TermNameType[]>()
                 )
             )
             .Returns(Task.FromResult(new DrugTermResults()));
@@ -77,8 +74,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
             await controller.GetAll(-1, DEFAULT_SEARCH_FROM,
                 DEFAULT_DRUG_RESOURCE_TYPE_LIST,
                 DEFAULT_INCLUDED_TERM_TYPE_LIST,
-                DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                DEFAULT_REQUESTED_FIELD_LIST
+                DEFAULT_EXCLUDED_TERM_TYPE_LIST
             );
 
             // Verify that the query layer is called:
@@ -86,7 +82,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
             //  b) exactly once.
             querySvc.Verify(
                 svc => svc.GetAll(DEFAULT_SEARCH_SIZE, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST, DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST, DEFAULT_REQUESTED_FIELD_LIST),
+                    DEFAULT_DRUG_RESOURCE_TYPE_LIST, DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST),
                 Times.Once,
                 "ITermsQueryService::GetAll() should be called once, with the updated value for size"
             );
@@ -106,8 +102,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<int>(),
                     It.IsAny<DrugResourceType[]>(),
                     It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<TermNameType[]>()
                 )
             )
             .Returns(Task.FromResult(new DrugTermResults()));
@@ -121,125 +116,9 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
             //  b) exactly once.
             querySvc.Verify(
                 svc => svc.GetAll(10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST, DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST, DEFAULT_REQUESTED_FIELD_LIST),
+                    DEFAULT_DRUG_RESOURCE_TYPE_LIST, DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST),
                 Times.Once,
                 "ITermsQueryService::GetAll() should be called once, with the updated value for from"
-            );
-        }
-
-        /// <summary>
-        /// Verify that GetAll behaves in the expected manner when requestedFields is null.
-        /// </summary>
-        [Fact]
-        public async void GetAll_NullRequestedFields()
-        {
-            // Create a mock query that always returns the same result.
-            Mock<IDrugsQueryService> querySvc = new Mock<IDrugsQueryService>();
-            querySvc.Setup(
-                svc => svc.GetAll(
-                    It.IsAny<int>(),
-                    It.IsAny<int>(),
-                    It.IsAny<DrugResourceType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
-                )
-            )
-            .Returns(Task.FromResult(new DrugTermResults()));
-
-            // Call the controller, we don't care about the actual return value.
-            DrugsController controller = new DrugsController(NullLogger<DrugsController>.Instance, querySvc.Object);
-            await controller.GetAll(10, -1, null);
-
-            // Verify that the query layer is called:
-            //  a) with the expected updated values for requestedFields.
-            //  b) exactly once.
-            querySvc.Verify(
-                svc => svc.GetAll(10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    DEFAULT_REQUESTED_FIELD_LIST),
-                Times.Once,
-                "ITermsQueryService::GetAll() should be called once, with the updated value for requestedFields"
-            );
-        }
-
-        /// <summary>
-        /// Verify that GetAll behaves in the expected manner when requestedFields is invalid
-        /// by having any array items that are null.
-        /// </summary>
-        [Fact]
-        public async void GetAll_InvalidRequestedFields()
-        {
-            // Create a mock query that always returns the same result.
-            Mock<IDrugsQueryService> querySvc = new Mock<IDrugsQueryService>();
-            querySvc.Setup(
-                svc => svc.GetAll(
-                    It.IsAny<int>(),
-                    It.IsAny<int>(),
-                    It.IsAny<DrugResourceType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
-                )
-            )
-            .Returns(Task.FromResult(new DrugTermResults()));
-
-            // Call the controller, we don't care about the actual return value.
-            DrugsController controller = new DrugsController(NullLogger<DrugsController>.Instance, querySvc.Object);
-            await controller.GetAll(10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    new string[] { null, null, null });
-
-            // Verify that the query layer is called:
-            //  a) with the expected updated values for requestedFields.
-            //  b) exactly once.
-            querySvc.Verify(
-                svc => svc.GetAll(10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    DEFAULT_REQUESTED_FIELD_LIST),
-                Times.Once,
-                "ITermsQueryService::GetAll() should be called once, with the updated value for requestedFields"
-            );
-        }
-
-        /// <summary>
-        /// Verify that GetAll behaves in the expected manner when requestedFields is an empty array.
-        /// </summary>
-        [Fact]
-        public async void GetAll_EmptyRequestedFields()
-        {
-            // Create a mock query that always returns the same result.
-            Mock<IDrugsQueryService> querySvc = new Mock<IDrugsQueryService>();
-            querySvc.Setup(
-                svc => svc.GetAll(
-                    It.IsAny<int>(),
-                    It.IsAny<int>(),
-                    It.IsAny<DrugResourceType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
-                )
-            )
-            .Returns(Task.FromResult(new DrugTermResults()));
-
-            // Call the controller, we don't care about the actual return value.
-            DrugsController controller = new DrugsController(NullLogger<DrugsController>.Instance, querySvc.Object);
-            await controller.GetAll(10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST, new string[] { });
-
-            // Verify that the query layer is called:
-            //  a) with the expected updated values for requestedFields.
-            //  b) exactly once.
-            querySvc.Verify(
-                svc => svc.GetAll(10, DEFAULT_SEARCH_FROM,
-                    DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST, DEFAULT_REQUESTED_FIELD_LIST),
-                Times.Once,
-                "ITermsQueryService::GetAll() should be called once, with the updated value for requestedFields"
             );
         }
 
@@ -252,8 +131,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
         {
             Mock<IDrugsQueryService> termsQueryService = new Mock<IDrugsQueryService>();
             DrugsController controller = new DrugsController(NullLogger<DrugsController>.Instance, termsQueryService.Object);
-            string[] requestedFields = new string[] { "termId", "name", "firstLetter", "prettyUrlName", "definition", "aliases", "drugInfoSummaryLink", "nciConceptId", "nciConceptName", "type", "termNameType" };
-
+            
             DrugTermResults drugTermResults = new DrugTermResults()
             {
                 Results = new DrugTerm[] {
@@ -340,23 +218,20 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<int>(),
                     It.IsAny<DrugResourceType[]>(),
                     It.IsAny<TermNameType[]>(),
-                    It.IsAny<TermNameType[]>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<TermNameType[]>()
                 )
             )
             .Returns(Task.FromResult(drugTermResults));
 
             DrugTermResults actualReslts = await controller.GetAll(5, 10, DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                requestedFields);
+                DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST);
 
             // Verify that the service layer is called:
             //  a) with the expected values.
             //  b) exactly once.
             termsQueryService.Verify(
                 svc => svc.GetAll(5, 10, DEFAULT_DRUG_RESOURCE_TYPE_LIST,
-                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST,
-                    new string[] { "termId", "name", "firstLetter", "prettyUrlName", "definition", "aliases", "drugInfoSummaryLink", "nciConceptId", "nciConceptName", "type", "termNameType" }
+                    DEFAULT_INCLUDED_TERM_TYPE_LIST, DEFAULT_EXCLUDED_TERM_TYPE_LIST
                 ),
                 Times.Once
             );

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Controllers/DrugsControllerTests.Search.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Controllers/DrugsControllerTests.Search.cs
@@ -28,8 +28,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<string>(),
                     It.IsAny<MatchType>(),
                     It.IsAny<int>(),
-                    It.IsAny<int>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<int>()
                 )
             )
             .Returns(Task.FromResult(new DrugTermResults()));
@@ -47,8 +46,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<string>(),
                     It.IsAny<MatchType>(),
                     It.IsAny<int>(),
-                    It.IsAny<int>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<int>()
                 ),
                 Times.Never
             );
@@ -109,8 +107,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     It.IsAny<string>(),
                     It.IsAny<MatchType>(),
                     It.IsAny<int>(),
-                    It.IsAny<int>(),
-                    It.IsAny<string[]>()
+                    It.IsAny<int>()
                 )
             )
             .Returns(Task.FromResult(testResults));
@@ -125,7 +122,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
             //  a) with the ID value.
             //  b) exactly once.
             querySvc.Verify(
-                svc => svc.Search(theName, MatchType.Begins, DEFAULT_SEARCH_SIZE, DEFAULT_SEARCH_FROM, DEFAULT_REQUESTED_FIELD_LIST),
+                svc => svc.Search(theName, MatchType.Begins, DEFAULT_SEARCH_SIZE, DEFAULT_SEARCH_FROM),
                 Times.Once,
                 $"ITermsQueryService::Search() should be called once, with id = '{theName}"
             );

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Controllers/DrugsControllerTests._Constants.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Controllers/DrugsControllerTests._Constants.cs
@@ -35,8 +35,5 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                             TermNameType.Broader, TermNameType.RelatedString, TermNameType.PreferredName };
 
         static readonly TermNameType[] DEFAULT_EXCLUDED_TERM_TYPE_LIST = { };
-
-        static readonly string[] DEFAULT_REQUESTED_FIELD_LIST = { "termId", "name", "firstLetter", "type", "termNameType", "prettyUrlName", "aliases", "definition", "drugInfoSummaryLink", "nciConceptId", "nciConceptName", "PreferredName" };
-
     }
 }

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Services/ESDrugsQueryServiceTest.Request.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/Services/ESDrugsQueryServiceTest.Request.cs
@@ -71,8 +71,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
             // We don't really care that this returns anything (for this test), only that the intercepting connection
             // sets up the request correctly.
             DrugTermResults result = await query.Expand(data.Letter, data.Size, data.From,
-                data.IncludeResourceTypes, data.IncludeNameTypes, data.ExcludeNameTypes,
-                new string[] { "termId", "name", "firstLetter", "prettyUrlName", "definition", "aliases", "drugInfoSummaryLink", "nciConceptId", "nciConceptName", "type", "termNameType" }
+                data.IncludeResourceTypes, data.IncludeNameTypes, data.ExcludeNameTypes
                 );
 
             Assert.Equal("/drugv1/terms/_search", esURI.AbsolutePath);
@@ -130,8 +129,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
             // We don't really care that this returns anything (for this test), only that the intercepting connection
             // sets up the request correctly.
             DrugTermResults result = await query.GetAll(data.Size, data.From,
-                data.IncludeResourceTypes, data.IncludeNameTypes, data.ExcludeNameTypes,
-                new string[] { "termId", "name", "firstLetter", "prettyUrlName", "definition", "aliases", "drugInfoSummaryLink", "nciConceptId", "nciConceptName", "type", "termNameType" }
+                data.IncludeResourceTypes, data.IncludeNameTypes, data.ExcludeNameTypes
                 );
 
             Assert.Equal("/drugv1/terms/_search", esURI.AbsolutePath);
@@ -241,9 +239,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
 
             // We don't really care that this returns anything (for this test), only that the intercepting connection
             // sets up the request correctly.
-            DrugTermResults result = await query.Search(data.SearchText, data.MatchType, data.Size, data.From,
-                new string[] { "termId", "name", "type", "prettyUrlName", "aliases", "definition", "PreferredName" }
-            );
+            DrugTermResults result = await query.Search(data.SearchText, data.MatchType, data.Size, data.From);
 
             Assert.Equal("/drugv1/terms/_search", esURI.AbsolutePath);
             Assert.Equal("application/json", esContentType);

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Begins_MultipleResourceTypes_MultipleIncludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Begins_MultipleResourceTypes_MultipleIncludes.cs
@@ -41,7 +41,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Begins_MultipleResourceTypes_No_Include_MultipleExcludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Begins_MultipleResourceTypes_No_Include_MultipleExcludes.cs
@@ -41,7 +41,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Begins_SingleResourceType_SingleInclude_SingleExclude.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Begins_SingleResourceType_SingleInclude_SingleExclude.cs
@@ -41,7 +41,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Contains_MultipleResourceTypes_MultipleIncludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Contains_MultipleResourceTypes_MultipleIncludes.cs
@@ -41,7 +41,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Contains_MultipleResourceTypes_No_Include_MultipleExcludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Contains_MultipleResourceTypes_No_Include_MultipleExcludes.cs
@@ -41,7 +41,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Contains_SingleResourceType_SingleInclude_SingleExclude.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/ExpandSvc_Contains_SingleResourceType_SingleInclude_SingleExclude.cs
@@ -41,7 +41,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Begins_MultipleResourceTypes_MultipleIncludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Begins_MultipleResourceTypes_MultipleIncludes.cs
@@ -39,7 +39,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Begins_MultipleResourceTypes_No_Include_MultipleExcludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Begins_MultipleResourceTypes_No_Include_MultipleExcludes.cs
@@ -39,7 +39,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Begins_SingleResourceType_SingleInclude_SingleExclude.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Begins_SingleResourceType_SingleInclude_SingleExclude.cs
@@ -39,7 +39,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Contains_MultipleResourceTypes_MultipleIncludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Contains_MultipleResourceTypes_MultipleIncludes.cs
@@ -39,7 +39,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Contains_MultipleResourceTypes_No_Include_MultipleExcludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Contains_MultipleResourceTypes_No_Include_MultipleExcludes.cs
@@ -39,7 +39,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Contains_SingleResourceType_SingleInclude_SingleExclude.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/GetAllSvc_Contains_SingleResourceType_SingleInclude_SingleExclude.cs
@@ -39,7 +39,8 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                     ""first_letter"",
                     ""type"",
                     ""term_name_type"",
-                    ""pretty_url_name""
+                    ""pretty_url_name"",
+                    ""preferred_name""
                 ]
             },
             ""sort"": [ { ""name"": {} } ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Begins_LongName.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Begins_LongName.cs
@@ -20,6 +20,9 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
         ""includes"": [
             ""aliases"",
             ""definition"",
+            ""drug_info_summary_link"",
+            ""nci_concept_id"",
+            ""nci_concept_name"",
             ""term_id"",
             ""name"",
             ""first_letter"",

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Begins_Olaparib.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Begins_Olaparib.cs
@@ -20,6 +20,9 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
         ""includes"": [
             ""aliases"",
             ""definition"",
+            ""drug_info_summary_link"",
+            ""nci_concept_id"",
+            ""nci_concept_name"",
             ""term_id"",
             ""name"",
             ""first_letter"",

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Contains_Cetuximab.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Contains_Cetuximab.cs
@@ -20,6 +20,9 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
         ""includes"": [
             ""aliases"",
             ""definition"",
+            ""drug_info_summary_link"",
+            ""nci_concept_id"",
+            ""nci_concept_name"",
             ""term_id"",
             ""name"",
             ""first_letter"",

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Contains_LongName.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Contains_LongName.cs
@@ -20,6 +20,9 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
         ""includes"": [
             ""aliases"",
             ""definition"",
+            ""drug_info_summary_link"",
+            ""nci_concept_id"",
+            ""nci_concept_name"",
             ""term_id"",
             ""name"",
             ""first_letter"",

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Contains_Paclitaxel.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_Contains_Paclitaxel.cs
@@ -20,6 +20,9 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
         ""includes"": [
             ""aliases"",
             ""definition"",
+            ""drug_info_summary_link"",
+            ""nci_concept_id"",
+            ""nci_concept_name"",
             ""term_id"",
             ""name"",
             ""first_letter"",

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_ZeroOffset_Trametinib.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/DrugsService/SearchSvc_ZeroOffset_Trametinib.cs
@@ -20,6 +20,9 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
         ""includes"": [
             ""aliases"",
             ""definition"",
+            ""drug_info_summary_link"",
+            ""nci_concept_id"",
+            ""nci_concept_name"",
             ""term_id"",
             ""name"",
             ""first_letter"",


### PR DESCRIPTION
(#26) Change path params to query string params
* Update DrugsController path params to query string params
* Update AutosuggestController path params to query string params
* Update integration tests to take query string params instead of paths
* Closes NCIOCPL#26

(#28) Remove requestedFields parameter
* Remove requestedFields from DrugsController
* Remove requestedFields from drugs query service interface
* Remove requestedFields from drugs query service ES implementation
* Refactor getFieldList method in drugs query service ES implementation
* Pass in all available fields in drugs query service ES implementation
* Remove requestedFields from expand tests
* Remove requestedFields from getall tests
* Remove requestedFields from search tests
* Remove requestedFields from query service tests
* Update field list in query service test data
* Remove default requestedFields constants
* Closes NCIOCPL#28