### PR TITLE
(#31) Add integration test for bad match on 2/3.

### DIFF
--- a/integration-tests/data/source/drug-es-mapping.json
+++ b/integration-tests/data/source/drug-es-mapping.json
@@ -1,167 +1,167 @@
 {
     "settings": {
-        "index": {
-            "number_of_shards": "1",
-            "analysis": {
-                "filter": {
-                    "autocomplete_filter": {
-                        "type": "edge_ngram",
-                        "min_gram": 1,
-                        "max_gram": 30,
-                        "token_chars": [
-                            "letter",
-                            "digit",
-                            "punctuation",
-                            "symbol"
-                        ]
-                    },
-                    "ngram_filter": {
-                        "type": "ngram",
-                        "min_gram": 1,
-                        "max_gram": 30,
-                        "token_chars": [
-                            "letter",
-                            "digit",
-                            "punctuation",
-                            "symbol"
-                        ]
-                    }
-                },
-                "analyzer": {
-                    "autocomplete_index": {
-                        "type": "custom",
-                        "tokenizer": "standard",
-                        "filter": [
-                            "lowercase",
-                            "autocomplete_filter",
-                            "asciifolding"
-                        ]
-                    },
-                    "lowercase_search": {
-                        "filter": [
-                            "lowercase",
-                            "asciifolding"
-                        ],
-                        "tokenizer": "keyword"
-                    },
-                    "ngram_analyzer": {
-                        "type": "custom",
-                        "tokenizer": "keyword",
-                        "filter": [
-                            "lowercase",
-                            "ngram_filter",
-                            "asciifolding"
-                        ]
-                    },
-                    "autocomplete_search": {
-                        "type": "custom",
-                        "tokenizer": "standard",
-                        "filter": [
-                            "lowercase",
-                            "asciifolding"
-                        ]
-                    }
-                },
-                "normalizer": {
-                    "caseinsensitive_normalizer": {
-                        "type": "custom",
-                        "char_filter": [],
-                        "filter": [
-                            "lowercase",
-                            "asciifolding"
-                        ]
-                    }
-                }
+      "index": {
+        "number_of_shards": "1",
+        "analysis": {
+          "filter": {
+            "autocomplete_filter": {
+              "type": "edge_ngram",
+              "min_gram": 1,
+              "max_gram": 30,
+              "token_chars": [
+                "letter",
+                "digit",
+                "punctuation",
+                "symbol"
+              ]
+            },
+            "ngram_filter": {
+              "type": "ngram",
+              "min_gram": 1,
+              "max_gram": 30,
+              "token_chars": [
+                "letter",
+                "digit",
+                "punctuation",
+                "symbol"
+              ]
             }
+          },
+          "analyzer": {
+            "autocomplete_index": {
+              "type": "custom",
+              "tokenizer": "classic",
+              "filter": [
+                "lowercase",
+                "autocomplete_filter",
+                "asciifolding"
+              ]
+            },
+            "lowercase_search": {
+              "filter": [
+                "lowercase",
+                "asciifolding"
+              ],
+              "tokenizer": "keyword"
+            },
+            "ngram_analyzer": {
+              "type": "custom",
+              "tokenizer": "keyword",
+              "filter": [
+                "lowercase",
+                "ngram_filter",
+                "asciifolding"
+              ]
+            },
+            "autocomplete_search": {
+              "type": "custom",
+              "tokenizer": "classic",
+              "filter": [
+                "lowercase",
+                "asciifolding"
+              ]
+            }
+          },
+          "normalizer": {
+            "caseinsensitive_normalizer": {
+              "type": "custom",
+              "char_filter": [],
+              "filter": [
+                "lowercase",
+                "asciifolding"
+              ]
+            }
+          }
         }
+      }
     },
     "mappings": {
-        "terms": {
-            "dynamic": "strict",
-            "properties": {
-                "name": {
-                    "type": "keyword",
-                    "normalizer": "caseinsensitive_normalizer",
-                    "fields": {
-                        "_autocomplete": {
-                            "type": "text",
-                            "analyzer": "autocomplete_index",
-                            "search_analyzer": "autocomplete_search"
-                        },
-                        "_contain": {
-                            "type": "text",
-                            "analyzer": "ngram_analyzer",
-                            "search_analyzer": "lowercase_search"
-                        }
-                    }
-                },
-                "type": {
-                    "type": "keyword"
-                },
-                "term_name_type": {
-                    "type": "keyword"
-                },
-                "first_letter": {
-                    "type": "keyword",
-                    "normalizer": "caseinsensitive_normalizer"
-                },
-                "preferred_name": {
-                    "type": "keyword",
-                    "normalizer": "caseinsensitive_normalizer"
-                },
-                "aliases": {
-                    "type": "nested",
-                    "include_in_root": true,
-                    "properties": {
-                        "type": {
-                            "type": "keyword"
-                        },
-                        "name": {
-                            "type": "keyword",
-                            "normalizer": "caseinsensitive_normalizer",
-                            "fields": {
-                                "_contain": {
-                                    "type": "text",
-                                    "analyzer": "ngram_analyzer",
-                                    "search_analyzer": "lowercase_search"
-                                }
-                            }
-                        }
-                    }
-                },
-                "definition": {
-                    "properties": {
-                        "html": {
-                            "type": "keyword"
-                        },
-                        "text": {
-                            "type": "keyword"
-                        }
-                    }
-                },
-                "term_id": {
-                    "type": "long"
-                },
-                "pretty_url_name": {
-                    "type": "keyword"
-                },
-                "nci_concept_id": {
-                    "type": "keyword"
-                },
-                "nci_concept_name": {
-                    "type": "keyword"
-                },
-                "drug_info_summary_link": {
-                    "properties": {
-                        "text": {
-                            "type": "keyword"
-                        },
-                        "url": {
-                            "type": "keyword"
-                        }
-                    }
-                }
+      "terms": {
+        "dynamic": "strict",
+        "properties": {
+          "name": {
+            "type": "keyword",
+            "normalizer": "caseinsensitive_normalizer",
+            "fields": {
+              "_autocomplete": {
+                "type": "text",
+                "analyzer": "autocomplete_index",
+                "search_analyzer": "autocomplete_search"
+              },
+              "_contain": {
+                "type": "text",
+                "analyzer": "ngram_analyzer",
+                "search_analyzer": "lowercase_search"
+              }
             }
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "term_name_type": {
+            "type": "keyword"
+          },
+          "first_letter": {
+            "type": "keyword",
+            "normalizer": "caseinsensitive_normalizer"
+          },
+          "preferred_name": {
+            "type": "keyword",
+            "normalizer": "caseinsensitive_normalizer"
+          },
+          "aliases": {
+            "type": "nested",
+            "include_in_root": true,
+            "properties": {
+              "type": {
+                "type": "keyword"
+              },
+              "name": {
+                "type": "keyword",
+                "normalizer": "caseinsensitive_normalizer",
+                "fields": {
+                  "_contain": {
+                    "type": "text",
+                    "analyzer": "ngram_analyzer",
+                    "search_analyzer": "lowercase_search"
+                  }
+                }
+              }
+            }
+          },
+          "definition": {
+            "properties": {
+              "html": {
+                "type": "keyword"
+              },
+              "text": {
+                "type": "keyword"
+              }
+            }
+          },
+          "term_id": {
+            "type": "long"
+          },
+          "pretty_url_name": {
+            "type": "keyword"
+          },
+          "nci_concept_id": {
+            "type": "keyword"
+          },
+          "nci_concept_name": {
+            "type": "keyword"
+          },
+          "drug_info_summary_link": {
+            "properties": {
+              "text": {
+                "type": "keyword"
+              },
+              "url": {
+                "type": "keyword"
+              }
+            }
+          }
         }
+      }
     }
-}
+  }

--- a/integration-tests/features/autosuggest/legacy-contains-two-thirds.json
+++ b/integration-tests/features/autosuggest/legacy-contains-two-thirds.json
@@ -1,0 +1,6 @@
+[
+    {
+        "termId": 742152,
+        "termName": "BET bromodomains 2/3/4 inhibitor MK-8628"
+    }
+]

--- a/integration-tests/features/autosuggest/legacy.feature
+++ b/integration-tests/features/autosuggest/legacy.feature
@@ -24,3 +24,4 @@ Feature: Autosuggest, including only PreferredName and USBrandName name types in
             | containing         | contains  | legacy-contains-containing.json   |
             # Path separator in term name
             | TLR5/TLR5          | contains  | legacy-contains-tlr5.json         |
+            | 2/3                | contains  | legacy-contains-two-thirds.json   |


### PR DESCRIPTION
Fix is in elasticsearch mapping file, installed by the loader. This adds
an integration test.