### PR TITLE
(#43) Adjust autosuggest contains query for exact match.

### DIFF
--- a/integration-tests/features/autosuggest/contains-alias-exact-match-on-punctuation.json
+++ b/integration-tests/features/autosuggest/contains-alias-exact-match-on-punctuation.json
@@ -1,0 +1,82 @@
+[
+    {
+        "termId": 776631,
+        "termName": "allogeneic anti-CD133 CAR T cells"
+    },
+    {
+        "termId": 799962,
+        "termName": "allogeneic anti-CD19 CAR CRISPR-edited T cells CTX110"
+    },
+    {
+        "termId": 799962,
+        "termName": "allogeneic anti-CD19 CAR-T cells CTX110"
+    },
+    {
+        "termId": 800688,
+        "termName": "allogeneic anti-CD20 CAR T lymphocytes PBCAR20A"
+    },
+    {
+        "termId": 799962,
+        "termName": "allogeneic CRISPR-Cas9-engineered anti-CD19 CAR T cells CTX110"
+    },
+    {
+        "termId": 792167,
+        "termName": "allogeneic engineered T cells expressing anti-CD123 chimeric antigen receptor"
+    },
+    {
+        "termId": 797352,
+        "termName": "anti-EGFR/anti-c-Met bispecific antibody EMB-01"
+    },
+    {
+        "termId": 798662,
+        "termName": "autologous anti-c-Met/PD-L1 CAR T cells"
+    },
+    {
+        "termId": 794777,
+        "termName": "autologous anti-CD19 CAR T cells JWCAR029"
+    },
+    {
+        "termId": 801949,
+        "termName": "Autologous Anti-CD19 CAR T-cells AUTO1"
+    },
+    {
+        "termId": 792748,
+        "termName": "autologous anti-CD19 CAR TCR-zeta/4-1BB-transduced T cells BinD19"
+    },
+    {
+        "termId": 802259,
+        "termName": "autologous anti-CD19 CAR-CD28 T cells KTE-X19"
+    },
+    {
+        "termId": 795543,
+        "termName": "autologous anti-CD19 CAR-CD3zeta-4-1BB-expressing T cells huCART19"
+    },
+    {
+        "termId": 768723,
+        "termName": "autologous anti-CD19 CAR-positive T lymphocytes KTE-C19"
+    },
+    {
+        "termId": 792521,
+        "termName": "autologous anti-CD19 CAR-T cells 4SCAR19"
+    },
+    {
+        "termId": 791274,
+        "termName": "autologous anti-CD19 CAR-T cells C-CAR011"
+    },
+    {
+        "termId": 791828,
+        "termName": "autologous anti-CD19 CAR-T cells SJCAR19"
+    },
+    {
+        "termId": 791274,
+        "termName": "autologous anti-CD19 CART cells C-CAR011"
+    },
+    {
+        "termId": 791828,
+        "termName": "autologous anti-CD19 CART cells SJCAR19"
+    },
+    {
+        "termId": 792746,
+        "termName": "autologous anti-CD19 chimeric antigen receptor T cells TBI-1501"
+    }
+]

--- a/integration-tests/features/autosuggest/contains-alias-match-on-word-boundary.json
+++ b/integration-tests/features/autosuggest/contains-alias-match-on-word-boundary.json
@@ -1,0 +1,82 @@
+[
+    {
+        "termId": 42286,
+        "termName": "2B1 Bispecific MAb"
+    },
+    {
+        "termId": 42286,
+        "termName": "2B1 Bispecific Murine MAb"
+    },
+    {
+        "termId": 688830,
+        "termName": "90Y anti-CD45 MAb BC8"
+    },
+    {
+        "termId": 744892,
+        "termName": "[131I] mAb HAb18G/CD147"
+    },
+    {
+        "termId": 690474,
+        "termName": "anti-ANG2 MAb MEDI-3617"
+    },
+    {
+        "termId": 747738,
+        "termName": "anti-CD19 MAb DI-B4"
+    },
+    {
+        "termId": 795705,
+        "termName": "anti-CD38 MAb TAK-079"
+    },
+    {
+        "termId": 769566,
+        "termName": "anti-CD47 Mab CC-90002"
+    },
+    {
+        "termId": 687567,
+        "termName": "anti-CTLA-4 mAb heavy and light chain RNA/GITRL RNA-transfected autologous DC"
+    },
+    {
+        "termId": 687567,
+        "termName": "anti-CTLA-4 mAb heavy and light chain RNA/GITRL RNA-transfected autologous dendritic cell"
+    },
+    {
+        "termId": 687564,
+        "termName": "anti-CTLA-4 mAb RNA-transfected autologous DC"
+    },
+    {
+        "termId": 687564,
+        "termName": "anti-CTLA-4 mAb RNA-transfected autologous dendritic cells"
+    },
+    {
+        "termId": 691187,
+        "termName": "anti-EGFR mAb ABT-806"
+    },
+    {
+        "termId": 686621,
+        "termName": "anti-EphA3 mAb KB004"
+    },
+    {
+        "termId": 681010,
+        "termName": "anti-HER2 mAb MGAH22"
+    },
+    {
+        "termId": 708211,
+        "termName": "anti-HER2 monoclonal antibody GT-Mab 7.3-GEX"
+    },
+    {
+        "termId": 365545,
+        "termName": "anti-huCD40 mAb"
+    },
+    {
+        "termId": 689549,
+        "termName": "anti-huGITR mAb TRX518"
+    },
+    {
+        "termId": 784959,
+        "termName": "anti-ICOS agonist MAb JTX-2011"
+    },
+    {
+        "termId": 780986,
+        "termName": "anti-IFNg mAb NI-0501"
+    }
+]

--- a/integration-tests/features/autosuggest/contains-all-records-exact-match-on-punctuation.json
+++ b/integration-tests/features/autosuggest/contains-all-records-exact-match-on-punctuation.json
@@ -1,0 +1,82 @@
+[
+    {
+        "termId": 776631,
+        "termName": "allogeneic anti-CD133 CAR T cells"
+    },
+    {
+        "termId": 799962,
+        "termName": "allogeneic anti-CD19 CAR CRISPR-edited T cells CTX110"
+    },
+    {
+        "termId": 799962,
+        "termName": "allogeneic anti-CD19 CAR-T cells CTX110"
+    },
+    {
+        "termId": 800688,
+        "termName": "allogeneic anti-CD20 CAR T lymphocytes PBCAR20A"
+    },
+    {
+        "termId": 799962,
+        "termName": "allogeneic CRISPR-Cas9 engineered anti-CD19 CAR T cells CTX110"
+    },
+    {
+        "termId": 799962,
+        "termName": "allogeneic CRISPR-Cas9-engineered anti-CD19 CAR T cells CTX110"
+    },
+    {
+        "termId": 792167,
+        "termName": "allogeneic engineered T cells expressing anti-CD123 chimeric antigen receptor"
+    },
+    {
+        "termId": 796718,
+        "termName": "allogeneic tri-functional anti-CD19 CAR-NK cells"
+    },
+    {
+        "termId": 797352,
+        "termName": "anti-EGFR/anti-c-Met bispecific antibody EMB-01"
+    },
+    {
+        "termId": 798662,
+        "termName": "autologous anti-c-Met/PD-L1 CAR T cells"
+    },
+    {
+        "termId": 778110,
+        "termName": "autologous anti-CD123 CAR TCR/4-1BB-expressing T lymphocytes"
+    },
+    {
+        "termId": 794777,
+        "termName": "autologous anti-CD19 CAR T cells JWCAR029"
+    },
+    {
+        "termId": 801949,
+        "termName": "Autologous Anti-CD19 CAR T-cells AUTO1"
+    },
+    {
+        "termId": 792748,
+        "termName": "autologous anti-CD19 CAR TCR-zeta/4-1BB-transduced T cells BinD19"
+    },
+    {
+        "termId": 792748,
+        "termName": "autologous anti-CD19 CAR TCR-zeta/4-1BB-transduced T lymphocytes BinD19"
+    },
+    {
+        "termId": 795543,
+        "termName": "autologous anti-CD19 CAR TCR-zeta/4-1BB-transduced T lymphocytes huCART19"
+    },
+    {
+        "termId": 802259,
+        "termName": "autologous anti-CD19 CAR-CD28 T cells KTE-X19"
+    },
+    {
+        "termId": 793525,
+        "termName": "autologous anti-CD19 CAR-CD3zeta-4-1BB-expressing T cells"
+    },
+    {
+        "termId": 795543,
+        "termName": "autologous anti-CD19 CAR-CD3zeta-4-1BB-expressing T cells huCART19"
+    },
+    {
+        "termId": 793588,
+        "termName": "autologous anti-CD19 CAR-CD3zeta-4-1BB-expressing T cells PZ01"
+    }
+]

--- a/integration-tests/features/autosuggest/contains-all-records-match-on-word-boundary.json
+++ b/integration-tests/features/autosuggest/contains-all-records-match-on-word-boundary.json
@@ -1,0 +1,82 @@
+[
+    {
+        "termId": 42286,
+        "termName": "2B1 Bispecific MAb"
+    },
+    {
+        "termId": 42286,
+        "termName": "2B1 Bispecific Murine MAb"
+    },
+    {
+        "termId": 688830,
+        "termName": "90Y anti-CD45 MAb BC8"
+    },
+    {
+        "termId": 744892,
+        "termName": "[131I] mAb HAb18G/CD147"
+    },
+    {
+        "termId": 690474,
+        "termName": "anti-ANG2 MAb MEDI-3617"
+    },
+    {
+        "termId": 747738,
+        "termName": "anti-CD19 MAb DI-B4"
+    },
+    {
+        "termId": 795705,
+        "termName": "anti-CD38 MAb TAK-079"
+    },
+    {
+        "termId": 769566,
+        "termName": "anti-CD47 Mab CC-90002"
+    },
+    {
+        "termId": 687567,
+        "termName": "anti-CTLA-4 mAb heavy and light chain RNA/GITRL RNA-transfected autologous DC"
+    },
+    {
+        "termId": 687567,
+        "termName": "anti-CTLA-4 mAb heavy and light chain RNA/GITRL RNA-transfected autologous dendritic cell"
+    },
+    {
+        "termId": 687564,
+        "termName": "anti-CTLA-4 mAb RNA-transfected autologous DC"
+    },
+    {
+        "termId": 687564,
+        "termName": "anti-CTLA-4 mAb RNA-transfected autologous dendritic cell vaccine"
+    },
+    {
+        "termId": 687564,
+        "termName": "anti-CTLA-4 mAb RNA-transfected autologous dendritic cells"
+    },
+    {
+        "termId": 687567,
+        "termName": "anti-CTLA4 mAb RNA/GITRL RNA-transfected autologous dendritic cell vaccine"
+    },
+    {
+        "termId": 691187,
+        "termName": "anti-EGFR mAb ABT-806"
+    },
+    {
+        "termId": 686621,
+        "termName": "anti-EphA3 mAb KB004"
+    },
+    {
+        "termId": 681010,
+        "termName": "anti-HER2 mAb MGAH22"
+    },
+    {
+        "termId": 708211,
+        "termName": "anti-HER2 monoclonal antibody GT-Mab 7.3-GEX"
+    },
+    {
+        "termId": 365545,
+        "termName": "anti-huCD40 mAb"
+    },
+    {
+        "termId": 689549,
+        "termName": "anti-huGITR mAb TRX518"
+    }
+]

--- a/integration-tests/features/autosuggest/contains-all-records-match-on-word-boundary2.json
+++ b/integration-tests/features/autosuggest/contains-all-records-match-on-word-boundary2.json
@@ -1,0 +1,14 @@
+[
+    {
+        "termId": 601983,
+        "termName": "androstane steroid HE3235"
+    },
+    {
+        "termId": 799647,
+        "termName": "chlorine dioxide sterilization"
+    },
+    {
+        "termId": 799071,
+        "termName": "submicron particle paclitaxel sterile suspension"
+    }
+]

--- a/integration-tests/features/autosuggest/contains-term-exact-match-on-punctuation.json
+++ b/integration-tests/features/autosuggest/contains-term-exact-match-on-punctuation.json
@@ -1,0 +1,82 @@
+[
+    {
+        "termId": 799962,
+        "termName": "allogeneic CRISPR-Cas9 engineered anti-CD19 CAR T cells CTX110"
+    },
+    {
+        "termId": 796718,
+        "termName": "allogeneic tri-functional anti-CD19 CAR-NK cells"
+    },
+    {
+        "termId": 778110,
+        "termName": "autologous anti-CD123 CAR TCR/4-1BB-expressing T lymphocytes"
+    },
+    {
+        "termId": 792748,
+        "termName": "autologous anti-CD19 CAR TCR-zeta/4-1BB-transduced T lymphocytes BinD19"
+    },
+    {
+        "termId": 795543,
+        "termName": "autologous anti-CD19 CAR TCR-zeta/4-1BB-transduced T lymphocytes huCART19"
+    },
+    {
+        "termId": 793525,
+        "termName": "autologous anti-CD19 CAR-CD3zeta-4-1BB-expressing T cells"
+    },
+    {
+        "termId": 793588,
+        "termName": "autologous anti-CD19 CAR-CD3zeta-4-1BB-expressing T cells PZ01"
+    },
+    {
+        "termId": 778659,
+        "termName": "autologous anti-CD19 CAR-expressing T lymphocytes"
+    },
+    {
+        "termId": 797095,
+        "termName": "autologous anti-CD19 CAR-expressing T lymphocytes CLIC-1901"
+    },
+    {
+        "termId": 794869,
+        "termName": "autologous anti-CD19 CAR-T cells IM19"
+    },
+    {
+        "termId": 792746,
+        "termName": "autologous anti-CD19 CAR-T cells TBI-1501"
+    },
+    {
+        "termId": 801949,
+        "termName": "autologous anti-CD19 chimeric antigen receptor T cells AUTO1"
+    },
+    {
+        "termId": 791274,
+        "termName": "autologous anti-CD19 chimeric antigen receptor T cells C-CAR011"
+    },
+    {
+        "termId": 791828,
+        "termName": "autologous anti-CD19 chimeric antigen receptor T cells SJCAR19"
+    },
+    {
+        "termId": 798924,
+        "termName": "autologous anti-CD19/CD22 CAR-T cells AUTO3"
+    },
+    {
+        "termId": 801497,
+        "termName": "autologous anti-CD20 CAR transduced CD4/CD8 enriched T cells MB-CART20.1"
+    },
+    {
+        "termId": 795556,
+        "termName": "autologous anti-CD22 CAR-4-1BB-TCRz-transduced T lymphocytes CART22-65s"
+    },
+    {
+        "termId": 798380,
+        "termName": "autologous anti-CD7 CAR/28zeta CRISPR-edited T lymphocytes"
+    },
+    {
+        "termId": 792542,
+        "termName": "autologous mRNA-modified anti-cMET CAR-T cells"
+    },
+    {
+        "termId": 766769,
+        "termName": "copper Cu 64 anti-CEA monoclonal antibody M5A"
+    }
+]

--- a/integration-tests/features/autosuggest/contains-term-match-on-word-boundary.json
+++ b/integration-tests/features/autosuggest/contains-term-match-on-word-boundary.json
@@ -1,0 +1,14 @@
+[
+    {
+        "termId": 601983,
+        "termName": "androstane steroid HE3235"
+    },
+    {
+        "termId": 799647,
+        "termName": "chlorine dioxide sterilization"
+    },
+    {
+        "termId": 799071,
+        "termName": "submicron particle paclitaxel sterile suspension"
+    }
+]

--- a/integration-tests/features/autosuggest/contains.feature
+++ b/integration-tests/features/autosuggest/contains.feature
@@ -1,0 +1,66 @@
+Feature: Autosuggest contains matches, with no filtering of alias types. This is a good place for
+    tests based on bugs from production.
+
+    Background:
+        * url apiHost
+
+    Scenario Outline: Given the search text, validate contains query for DrugTerms.
+        Search term is `<search>`.
+
+        Given path 'Autosuggest'
+        And params { searchText: <search>, matchType: contains, size: 20, includeResourceTypes: ['DrugTerm'] }
+        When method get
+        Then status 200
+        And match response == read( expected )
+
+        Examples:
+            | search             | expected                                        |
+            | anti-c             | contains-term-exact-match-on-punctuation.json   |
+            | ster               | contains-term-match-on-word-boundary.json       |
+
+    Scenario Outline: Given the search text, validate contains query for DrugAliases.
+        Search term is `<search>`.
+
+        Given path 'Autosuggest'
+        And params { searchText: <search>, matchType: contains, size: 20, includeResourceTypes: ['DrugAlias'] }
+        When method get
+        Then status 200
+        And match response == read( expected )
+
+        Examples:
+            | search             | expected                                         |
+            | anti-c             | contains-alias-exact-match-on-punctuation.json   |
+            | mab                | contains-alias-match-on-word-boundary.json       |
+
+
+    Scenario Outline: Given the search text, validate contains query for all resource types.
+        Search term is `<search>`.
+
+        Given path 'Autosuggest'
+        And params { searchText: <search>, matchType: contains, size: 20, includeResourceTypes: ['DrugTerm','DrugAlias'] }
+        When method get
+        Then status 200
+        And match response == read( expected )
+
+        Examples:
+            | search             | expected                                               |
+            | anti-c             | contains-all-records-exact-match-on-punctuation.json   |
+            | mab                | contains-all-records-match-on-word-boundary.json       |
+            | ster               | contains-all-records-match-on-word-boundary2.json      |
+
+
+    Scenario Outline: Given the search text, validate contains query for default resource types.
+        Search term is `<search>`.
+
+        Given path 'Autosuggest'
+        And params { searchText: <search>, matchType: contains, size: 20 }
+        When method get
+        Then status 200
+        And match response == read( expected )
+
+        Examples:
+            | search             | expected                                               |
+            # Default should be the same results as all, so let's use the same results files.
+            | anti-c             | contains-all-records-exact-match-on-punctuation.json   |
+            | mab                | contains-all-records-match-on-word-boundary.json       |
+            | ster               | contains-all-records-match-on-word-boundary2.json      |

--- a/src/NCI.OCPL.Api.DrugDictionary/Services/ESAutosuggestQueryService.cs
+++ b/src/NCI.OCPL.Api.DrugDictionary/Services/ESAutosuggestQueryService.cs
@@ -190,6 +190,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Services
              *         "bool": {
              *             "must": [
              *                 { "match_phrase": {"name._autocomplete": "dox"} },
+             *                 { "match": {"name._contain": "dox"}},
              *                 { "terms": { "type": [ "DrugAlias", "DrugTerm" ] } },
              *                 { "terms": { "term_name_type": [ "PreferredName", "Synonym", "USbrandname" ] } }
              *             ],
@@ -209,6 +210,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Services
             {
                 Query =
                         new MatchPhraseQuery { Field = "name._autocomplete", Query = query.ToString() } &&
+                        new MatchQuery { Field = "name._contain", Query = query.ToString() } &&
                         new TermsQuery { Field = "type", Terms = includeResourceTypes.Select(p => p.ToString()) }  &&
                         new TermsQuery {Field = "term_name_type", Terms = includeNameTypes.Select(p => p.ToString()) } &&
                         !new PrefixQuery { Field = "name", Value = query } &&

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/AutosuggestService/AutosuggestSvc_Contains_MultipleResourceTypes_MultipleIncludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/AutosuggestService/AutosuggestSvc_Contains_MultipleResourceTypes_MultipleIncludes.cs
@@ -31,6 +31,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                 ""bool"": {
                     ""must"": [
                         { ""match"": { ""name._autocomplete"": { ""query"": ""bevaciz"", ""type"": ""phrase"" } } },
+                        { ""match"": {""name._contain"": { ""query"": ""bevaciz"" } } },
                         { ""terms"": { ""type"": [ ""DrugAlias"", ""DrugTerm"" ] } },
                         { ""terms"": { ""term_name_type"": [ ""USBrandName"", ""Synonym"" ] } }
                     ],

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/AutosuggestService/AutosuggestSvc_Contains_MultipleResourceTypes_No_Include_MultipleExcludes.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/AutosuggestService/AutosuggestSvc_Contains_MultipleResourceTypes_No_Include_MultipleExcludes.cs
@@ -31,6 +31,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                 ""bool"": {
                     ""must"": [
                         { ""match"": { ""name._autocomplete"": { ""query"": ""ZFN ZFN-758"", ""type"": ""phrase"" } } },
+                        { ""match"": {""name._contain"": { ""query"": ""ZFN ZFN-758"" } } },
                         { ""terms"": { ""type"": [ ""DrugAlias"", ""DrugTerm"" ] } }
                     ],
                     ""must_not"": [

--- a/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/AutosuggestService/AutosuggestSvc_Contains_SingleResourceType_SingleInclude_SingleExclude.cs
+++ b/test/NCI.OCPL.Api.DrugDictionary.Tests/Tests/TestDataObjects/AutosuggestService/AutosuggestSvc_Contains_SingleResourceType_SingleInclude_SingleExclude.cs
@@ -31,6 +31,7 @@ namespace NCI.OCPL.Api.DrugDictionary.Tests
                 ""bool"": {
                     ""must"": [
                         { ""match"": { ""name._autocomplete"": { ""query"": ""gadavi"", ""type"": ""phrase"" } } },
+                        { ""match"": {""name._contain"": { ""query"": ""gadavi"" } } },
                         { ""terms"": { ""type"": [ ""DrugTerm"" ] } },
                         { ""terms"": { ""term_name_type"": [ ""USBrandName"" ] } }
                     ],


### PR DESCRIPTION
Update query to make an exact match when punctuation is encountered
while still respecting word boundaries.
- Update unit tests to verify the new request body structure.
- Additional integration tests.

Close #43 
