### PR TITLE
(#91) Bump NSwag.AspNetCore to v13.20

### DIFF
--- a/src/NCI.OCPL.Api.DrugDictionary/NCI.OCPL.Api.DrugDictionary.csproj
+++ b/src/NCI.OCPL.Api.DrugDictionary/NCI.OCPL.Api.DrugDictionary.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="Elasticsearch.Net" Version="7.9.*" />
         <PackageReference Include="NCI.OCPL.Api.Common" Version="2.1.*" />
-        <PackageReference Include="NSwag.AspNetCore" Version="13.11.*" />
+        <PackageReference Include="NSwag.AspNetCore" Version="13.20.*" />
         <PackageReference Include="NEST" Version="7.9.*" />
     </ItemGroup>
 


### PR DESCRIPTION
Closes #91

Testing needs:
- Standard regression tests
- Verify navigating to https://webapis-dev.cancer.gov/drugdictionary/v1/index.html?configUrl=https://jumpy-floor.surge.sh/test.json displays the drug dictionary Swagger page.
